### PR TITLE
Adds code to check for existing nodes and skip unless flag is set

### DIFF
--- a/provision-spark.yml
+++ b/provision-spark.yml
@@ -41,6 +41,14 @@
           num_spark_master_nodes: "{{groups['spark_master'] | default([]) | length}}"
           num_spark_nodes: "{{groups['spark'] | default([]) | length}}"
           num_zk_nodes: "{{groups['zookeeper'] | default([]) | length}}"
+      # if an existing set of Spark nodes were found, throw an error unless
+      # the reuse_existing_nodes flag was set to 'true' or 'yes')
+      - block:
+        - name: Fail playbook run if existing nodes found and user did not request reuse
+          fail:
+            msg: "Found an existing set of nodes - {{(((groups['spark_master'] | default([])) + (groups['spark'] | default([]))) | to_yaml).split('\n').0}}; aborting playbook run"
+          when: not((reuse_existing_nodes | default(false)) | bool)
+        when: (num_spark_master_nodes | int) + (num_spark_nodes | int) > 0
       # if at least one master node was not found (or at least one master node
       # is not defined in the node_map), then it's an error
       - fail:


### PR DESCRIPTION
The changes in this pull request modify the existing `provision-spark.yml` playbook so that:

* if a set of existing Spark nodes (one or more) are found during the playbook run that match the tags that were passed into the playbook, then an error is thrown unless the newly added `reuse_existing_nodes` flag is set (to either `true` or `yes`)
* if that flag is set and an existing set of Spark nodes are found during the playbook run, then those nodes will be used for the planned Spark deployment

This new `reuse_existing_nodes` flag defaults to `false` if it is not defined during the playbook run, so by default the `provision-spark.yml` playbook will fail with a simple error rather than reusing the existing (matching) nodes for the Spark deployment. This prevents users from accidentally targeting an existing cluster/ensemble by passing the wrong tags into the playbook run.

This flag becomes useful in the scenario where the playbook as created a new set of target nodes in a target cloud environment but the playbook then failed part way through the remaining plays in the playbook. In that scenario, this flag can be set by the user to target the (partially configured) set of existing nodes in the rest of the playbook run (rather than forcing the user to start over by redeploying the existing nodes).